### PR TITLE
Fix skipped events.

### DIFF
--- a/src/linux/cl-fsnotify-inotify.lisp
+++ b/src/linux/cl-fsnotify-inotify.lisp
@@ -98,19 +98,30 @@
    (remhash path (inotify-path-hash inotify-instance))
    (remhash wd (inotify-wd-hash inotify-instance)))))
 
-(defun get-event (inotify-instance)
- (let ((buffer (inotify-buffer inotify-instance)))
-  (when (plusp (foreign-funcall "read" :int (inotify-fd inotify-instance) :pointer buffer :int event-size :int))
-    (with-foreign-slots ((wd mask len) buffer struct-inotify-event)
-      (let ((name (if (plusp len)
-                   (foreign-string-to-lisp (foreign-slot-pointer buffer '(:struct struct-inotify-event) 'name) :max-chars len)
-                   "")))
-       (cons (concatenate 'string (gethash wd (inotify-wd-hash inotify-instance)) name) (foreign-bitfield-symbols 'inotify-flag mask)))))))
-
 (defun get-events (inotify-instance)
-  (loop as event = (get-event inotify-instance)
-        while event
-        collect event))
+  (let ((buffer (inotify-buffer inotify-instance))
+        events-queue)
+    (loop
+      for read = (foreign-funcall "read" :int (inotify-fd inotify-instance) :pointer buffer :int event-size :int)
+      while (plusp read)
+      do (loop
+           with offset = 0
+           with offset-buffer = (inc-pointer buffer offset)
+           while (< offset read)
+           do (with-foreign-slots ((wd mask len) offset-buffer (:struct struct-inotify-event))
+                (let ((name (if (plusp len)
+                                (foreign-string-to-lisp (foreign-slot-pointer offset-buffer '(:struct struct-inotify-event) 'name) :max-chars len)
+                                "")))
+                  (let ((result (cons (concatenate 'string (gethash wd (inotify-wd-hash inotify-instance)) name) (foreign-bitfield-symbols 'inotify-flag mask))))
+                    (if events-queue
+                        (let ((cons (list result)))
+                          (setf (cddr events-queue) cons
+                                (cdr events-queue) cons))
+                        (let ((queue (list (list result))))
+                          (setf (cdr queue) (car queue)
+                                events-queue queue)))))
+                (incf offset (+ raw-event-size len))))
+      finally (return (car events-queue)))))
 
 (defmacro with-inotify ((name) &body body)
  `(let ((,name (open-inotify)))

--- a/src/linux/cl-fsnotify-inotify.lisp
+++ b/src/linux/cl-fsnotify-inotify.lisp
@@ -79,9 +79,10 @@
 
 (defun close-inotify (inotify-instance)
  (let ((hash (inotify-wd-hash inotify-instance)))
-  (maphash #'(lambda (wd path) 
-             (c-inotify-rm-watch (inotify-fd inotify-instance) wd)
-             (remhash wd hash)) hash)
+  (maphash (lambda (wd path)
+           (declare (ignore path))
+           (c-inotify-rm-watch (inotify-fd inotify-instance) wd)
+           (remhash wd hash)) hash)
   (foreign-free (inotify-buffer inotify-instance))
   (foreign-funcall "close" :int (inotify-fd inotify-instance) :int)))
 

--- a/src/linux/cl-fsnotify-inotify.lisp
+++ b/src/linux/cl-fsnotify-inotify.lisp
@@ -70,12 +70,14 @@
             (len        :uint32)
             (name       :char))
 
+(defconstant +buffer-size+ 4096)
+
 (defun open-inotify ()
  (make-instance 'inotify-tracker
   :fd (c-inotify-init o-nonblock)
   :path-hash (make-hash-table :test 'equal)
   :wd-hash (make-hash-table :test 'equal)
-  :buffer (foreign-alloc :char :count event-size)))
+  :buffer (foreign-alloc :char :count +buffer-size+)))
 
 (defun close-inotify (inotify-instance)
  (let ((hash (inotify-wd-hash inotify-instance)))
@@ -103,7 +105,7 @@
   (let ((buffer (inotify-buffer inotify-instance))
         events-queue)
     (loop
-      for read = (foreign-funcall "read" :int (inotify-fd inotify-instance) :pointer buffer :int event-size :int)
+      for read = (foreign-funcall "read" :int (inotify-fd inotify-instance) :pointer buffer :int +buffer-size+ :int)
       while (plusp read)
       do (loop
            with offset = 0

--- a/src/linux/grovel-inotify.lisp
+++ b/src/linux/grovel-inotify.lisp
@@ -35,5 +35,8 @@
 (constant (in-oneshot       "IN_ONESHOT"))
 (constant (in-all-events    "IN_ALL_EVENTS"))
 
+(define "RAW_EVENT_SIZE" "sizeof(struct inotify_event)")
+(constant (raw-event-size   "RAW_EVENT_SIZE"))
+
 (define "EVENT_SIZE" "(sizeof(struct inotify_event) + NAME_MAX + 1)")
 (constant (event-size       "EVENT_SIZE"))

--- a/src/linux/grovel-inotify.lisp
+++ b/src/linux/grovel-inotify.lisp
@@ -37,6 +37,3 @@
 
 (define "RAW_EVENT_SIZE" "sizeof(struct inotify_event)")
 (constant (raw-event-size   "RAW_EVENT_SIZE"))
-
-(define "EVENT_SIZE" "(sizeof(struct inotify_event) + NAME_MAX + 1)")
-(constant (event-size       "EVENT_SIZE"))


### PR DESCRIPTION
As discussed in [this issue](https://github.com/howeyc/cl-fsnotify/issues/3), the Linux inotify code currently skips events. The commits here fix that, one other unused variable warning and then increase the buffer size to lower the number of read calls overall.
